### PR TITLE
Fully fledged docker image

### DIFF
--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -1,4 +1,4 @@
-FROM openproject/core
+FROM openproject/core:5.0
 MAINTAINER operations@openproject.com
 
 ENV DATABASE_URL=postgres://openproject:openproject@127.0.0.1/openproject

--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -1,0 +1,41 @@
+FROM openproject/core
+MAINTAINER operations@openproject.com
+
+ENV DATABASE_URL=postgres://openproject:openproject@127.0.0.1/openproject
+ENV RAILS_ENV=production
+ENV MIGRATE=true
+ENV HEROKU=true
+ENV SECRET_KEY_BASE=OVERWRITE_ME
+
+USER root
+RUN apt-get update -qq && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		memcached \
+		postfix \
+		postgresql \
+		apache2 \
+		supervisor && \
+	apt-get clean
+
+RUN a2enmod proxy proxy_http && rm -f /etc/apache2/sites-enabled/000-default.conf
+
+USER postgres
+RUN /etc/init.d/postgresql start && \
+    psql --command "CREATE USER openproject WITH SUPERUSER PASSWORD 'openproject';" && \
+    createdb -O openproject openproject
+RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.4/main/pg_hba.conf
+RUN echo "listen_addresses='*'" >> /etc/postgresql/9.4/main/postgresql.conf
+
+USER root
+COPY docker /usr/src/app/docker
+COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+RUN /etc/init.d/postgresql start && bundle exec rake db:schema:load
+
+# ports
+EXPOSE 80 5432
+
+# volumes to export
+VOLUME ["/var/lib/postgresql/9.4/main"]
+
+CMD ["/usr/bin/supervisord"]

--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -14,7 +14,7 @@ RUN apt-get update -qq && \
 		postgresql \
 		apache2 \
 		supervisor && \
-	apt-get clean
+	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod proxy proxy_http && rm -f /etc/apache2/sites-enabled/000-default.conf
 

--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -1,4 +1,4 @@
-FROM openproject/core:5.0
+FROM openproject/community:5.0-base
 MAINTAINER operations@openproject.com
 
 ENV DATABASE_URL=postgres://openproject:openproject@127.0.0.1/openproject

--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -3,7 +3,6 @@ MAINTAINER operations@openproject.com
 
 ENV DATABASE_URL=postgres://openproject:openproject@127.0.0.1/openproject
 ENV RAILS_ENV=production
-ENV MIGRATE=true
 ENV HEROKU=true
 ENV SECRET_KEY_BASE=OVERWRITE_ME
 
@@ -19,18 +18,12 @@ RUN apt-get update -qq && \
 
 RUN a2enmod proxy proxy_http && rm -f /etc/apache2/sites-enabled/000-default.conf
 
-USER postgres
-RUN /etc/init.d/postgresql start && \
-    psql --command "CREATE USER openproject WITH SUPERUSER PASSWORD 'openproject';" && \
-    createdb -O openproject openproject
 RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.4/main/pg_hba.conf
 RUN echo "listen_addresses='*'" >> /etc/postgresql/9.4/main/postgresql.conf
+RUN rm -rf /var/lib/postgresql/9.4/main && mkdir -p /var/lib/postgresql/9.4/main && chown -R postgres:postgres /var/lib/postgresql/9.4
 
-USER root
 COPY docker /usr/src/app/docker
 COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-
-RUN /etc/init.d/postgresql start && bundle exec rake db:schema:load
 
 # ports
 EXPOSE 80 5432
@@ -38,4 +31,4 @@ EXPOSE 80 5432
 # volumes to export
 VOLUME ["/var/lib/postgresql/9.4/main"]
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/src/app/docker/entrypoint"]

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+PGDATA=${PGDATA:=/var/lib/postgresql/9.4/main}
+PGUSER=${PGUSER:=postgres}
+PGPASSWORD=${PGPASSWORD:=postgres}
+PGBIN="/usr/lib/postgresql/9.4/bin"
+
+dbhost=$(ruby -ruri -e 'puts URI(ENV.fetch("DATABASE_URL")).host')
+pwfile=$(mktemp)
+chown postgres $pwfile
+echo "$PGPASSWORD" > $pwfile
+
+indent() {
+	sed -u 's/^/       /'
+}
+
+migrate() {
+	pushd /usr/src/app
+	/etc/init.d/memcached start
+	rake db:migrate db:seed
+	/etc/init.d/memcached stop
+	chown app:app db/schema.rb
+	popd
+}
+
+if [ "$dbhost" = "127.0.0.1" ]; then
+	# initialize cluster if it does not exist yet
+	if [ -f "$PGDATA/PG_VERSION" ]; then
+		echo "-----> Database cluster already exists, not modifying."
+		/etc/init.d/postgresql start | indent
+		migrate | indent
+		/etc/init.d/postgresql stop | indent
+	else
+		echo "-----> Database cluster not found. Creating a new one in $PGDATA..."
+		chown -R postgres:postgres $PGDATA
+		su postgres -c "$PGBIN/initdb --pgdata=${PGDATA} --username=${PGUSER} --encoding=unicode --auth=trust --pwfile=$pwfile" | indent
+		rm -f $pwfile
+		/etc/init.d/postgresql start | indent
+		su postgres -c "$PGBIN/psql --command \"CREATE USER openproject WITH SUPERUSER PASSWORD 'openproject';\"" | indent
+		su postgres -c "$PGBIN/createdb -O openproject openproject" | indent
+		migrate | indent
+		/etc/init.d/postgresql stop | indent
+	fi
+else
+	echo "-----> You're using an external database. Not initializing a local database cluster."
+	migrate | indent
+fi
+
+echo "-----> Database setup finished."
+echo "       On first installation, the default admin credentials are login: admin, password: admin"
+
+echo "-----> Launching supervisord..."
+exec /usr/bin/supervisord

--- a/docker/proxy
+++ b/docker/proxy
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+[ -f /etc/apache2/sites-enabled/openproject.conf ] || erb -r time /usr/src/app/docker/proxy.conf.erb > /etc/apache2/sites-enabled/openproject.conf
+exec /usr/sbin/apache2ctl -DFOREGROUND

--- a/docker/proxy.conf.erb
+++ b/docker/proxy.conf.erb
@@ -1,0 +1,7 @@
+<VirtualHost *:80>
+  ServerName <%= ENV.fetch('SERVER_NAME') { "_default_" } %>
+  <Location />
+    ProxyPass http://127.0.0.1:8080/
+    ProxyPassReverse http://127.0.0.1:8080/
+  </Location>
+</VirtualHost>

--- a/docker/proxy.conf.erb
+++ b/docker/proxy.conf.erb
@@ -1,7 +1,11 @@
 <VirtualHost *:80>
   ServerName <%= ENV.fetch('SERVER_NAME') { "_default_" } %>
+  DocumentRoot /usr/src/app/public
+
+  ProxyRequests off
+
   <Location />
-    ProxyPass http://127.0.0.1:8080/
+    ProxyPass http://127.0.0.1:8080/ retry=0
     ProxyPassReverse http://127.0.0.1:8080/
   </Location>
 </VirtualHost>

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -2,33 +2,51 @@
 nodaemon=true
 
 [program:web]
+priority=4
 user=app
 directory=/usr/src/app
 command=./docker/web
 autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
 
 [program:worker]
+priority=5
 user=app
 directory=/usr/src/app
 command=./docker/worker
 autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
 
 [program:memcached]
+priority=100
 user=app
 command=/usr/bin/memcached
 autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
 
 [program:apache2]
+priority=2
 directory=/usr/src/app
 command=./docker/proxy
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
 
 [program:postfix]
+priority=100
 directory=/etc/postfix
 command=/usr/sbin/postfix -c /etc/postfix start
 startsecs=0
 autorestart=false
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log
 
-[program:postgresql]
-command=/usr/lib/postgresql/9.4/bin/postgres -D /var/lib/postgresql/9.4/main -c config_file=/etc/postgresql/9.4/main/postgresql.conf
+[program:postgres]
 user=postgres
+priority=1
+command=/usr/lib/postgresql/9.4/bin/postgres -D /var/lib/postgresql/9.4/main -c config_file=/etc/postgresql/9.4/main/postgresql.conf
 autorestart=true
+stderr_logfile = /var/log/supervisor/%(program_name)s-stderr.log
+stdout_logfile = /var/log/supervisor/%(program_name)s-stdout.log

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,34 @@
+[supervisord]
+nodaemon=true
+
+[program:web]
+user=app
+directory=/usr/src/app
+command=./docker/web
+autorestart=true
+
+[program:worker]
+user=app
+directory=/usr/src/app
+command=./docker/worker
+autorestart=true
+
+[program:memcached]
+user=app
+command=/usr/bin/memcached
+autorestart=true
+
+[program:apache2]
+directory=/usr/src/app
+command=./docker/proxy
+
+[program:postfix]
+directory=/etc/postfix
+command=/usr/sbin/postfix -c /etc/postfix start
+startsecs=0
+autorestart=false
+
+[program:postgresql]
+command=/usr/lib/postgresql/9.4/bin/postgres -D /var/lib/postgresql/9.4/main -c config_file=/etc/postgresql/9.4/main/postgresql.conf
+user=postgres
+autorestart=true


### PR DESCRIPTION
I've just pushed an example docker image resulting from these changes, and you can now do:

``` bash
docker run -it  -p 8080:80 \
  -v $(pwd)/pgdata:/var/lib/postgresql/9.4/main \
  -v $(pwd)/logs:/var/log/supervisor \
  -e SECRET_KEY_BASE=changeme \
  openproject/community
```

Then:

``` bash
curl localhost:8080
```

And get a fully working openproject install. Database files and logs are stored in mounted volumes, so that you don't lose your state if you restart the container. It is also very easy to link with an external postgres db/container if wanted (just pass `-e DATABASE_URL=...`).

Additional configuration must be done with env variables, preferably stored in an `env-file`.

This is still a work in progress, it lacks support for svn/git repos, but if you can try it out that'd be great!

/cc @machisuji @oliverguenther 
